### PR TITLE
Include memory_map xml files required by cfg files in install folder

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -90,7 +90,7 @@ $(THE_MANUAL): %.pdf: %.tex
 
 TCL_PATH = tcl
 # command to find paths of script files, relative to TCL_PATH
-TCL_FILES = find $(srcdir)/$(TCL_PATH) -name '*.cfg' -o -name '*.tcl' -o -name '*.txt' | \
+TCL_FILES = find $(srcdir)/$(TCL_PATH) -name '*.cfg' -o -name '*.tcl' -o -name '*.txt' -o -name '*.xml' | \
 		sed -e 's,^$(srcdir)/$(TCL_PATH),,'
 
 dist-hook:


### PR DESCRIPTION
The memory_map.xml files referred to by the adspxxx.cfg files are missing from the installation after running "make install"

Added .xml to the search pattern for the TCL_FILES collection