### PR TITLE
Add latest config files for ADI MAX MCUs

### DIFF
--- a/tcl/target/max32520.cfg
+++ b/tcl/target/max32520.cfg
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Maxim Integrated MAX32520 OpenOCD target configuration file
+# www.maximintegrated.com
+
+# Set the reset pin configuration
+reset_config srst_only
+adapter srst delay 200
+
+# Set flash parameters
+set FLASH_BASE 0x10000000
+set FLASH_SIZE 0x200000
+set FLC_BASE 0x40029000
+set FLASH_SECTOR 0x2000
+set FLASH_CLK 120
+
+set FLASH_OPTIONS 0x23
+
+source [find target/max32xxx.cfg]
+
+proc max32520_aes256_reset_init {} {
+    # Enable encryption and 256 bit key
+    mww 0x40000000 0x320002
+}
+
+# Create custom reset sequence to set the AES keysize
+if { [expr $FLASH_OPTIONS & 0x40] } {
+    $_CHIPNAME.cpu configure -event reset-init { max32520_aes256_reset_init }
+}

--- a/tcl/target/max32570.cfg
+++ b/tcl/target/max32570.cfg
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Maxim Integrated MAX32570 OpenOCD target configuration file
+# www.maximintegrated.com
+
+# Set the reset pin configuration
+reset_config srst_only
+adapter srst delay 200
+
+set CHIPNAME max32570
+
+# Set flash parameters
+set FLASH_BASE 0x10000000
+set FLASH_SIZE 0x80000
+set FLC_BASE 0x40029000
+set FLASH_SECTOR 0x2000
+set FLASH_CLK 96
+set FLASH_OPTIONS 0x01
+
+# Enable or disable QSPI driver
+set QSPI_ENABLE 0
+
+global QSPI_VDDIOH
+# 1: Run QSPI at VDDIOH (3.3V)
+# 0: Run QSPI at VDDIO  (1.8V)
+set QSPI_VDDIOH 1
+
+# Setup QSPI options
+set QSPI_ADDR_BASE 0x08000000
+set QSPI_ADDR_SIZE 0x0800000
+set QSPI_OPTIONS 0x0
+
+# Use Serial Wire Debug
+transport select swd
+
+source [find target/max32xxx.cfg]
+
+# Add additional flash bank
+set FLASH_BASE 0x10080000
+set FLC_BASE 0x40029400
+
+flash bank $_CHIPNAME.flash1 max32xxx $FLASH_BASE $FLASH_SIZE 0 0 $_CHIPNAME.cpu \
+$FLC_BASE $FLASH_SECTOR $FLASH_CLK $FLASH_OPTIONS
+
+if {$QSPI_ENABLE == 1} {
+
+    if {$QSPI_VDDIOH != 0} {
+      echo "Warning - using VDDIOH (3.3V) for QSPI"
+    }
+
+    # Initialize the flash bank
+    flash bank $_CHIPNAME.qspi_flash max32xxx_qspi $QSPI_ADDR_BASE $QSPI_ADDR_SIZE \
+      0 0 $_CHIPNAME.cpu $QSPI_OPTIONS
+
+    source [find mem_helper.tcl]
+
+    # Setup the hardware to use the QSPI peripheral
+    proc init_spi {} {
+
+      global QSPI_VDDIOH
+
+      set CLKDIS0_ADDR 0x40000024
+      set CLKDIS1_ADDR 0x40000048
+      set PERRST_ADDR  0x40000044
+
+      set GPIO1_EN_ADDR  0x40009000
+      set GPIO1_OUT_EN_ADDR  0x4000900C
+      set GPIO1_OUT_SET_ADDR  0x4000901C
+      set GPIO1_EN1_ADDR 0x40009068
+      set GPIO1_EN2_ADDR 0x40009074
+      set GPIO1_DS0_ADDR 0x400090B0
+      set GPIO1_DS1_ADDR 0x400090B4
+      set GPIO1_VSSEL_ADDR 0x400090C0
+
+      set GPIO1_SPI_MASK 0xF63FFFFF
+      set GPIO1_RST_MASK 0x06000000
+
+      # Enable SPI and GPIO1 clocks
+      set TEMP [mrw $CLKDIS0_ADDR]
+      set TEMP_MOD [expr { $TEMP & 0x3FFFFFF8} ]
+      mww $CLKDIS0_ADDR $TEMP_MOD
+
+      # Enable the SPI XIP cache
+      set TEMP [mrw $CLKDIS1_ADDR]
+      set TEMP_MOD [expr { $TEMP & 0xFFFFE7FF} ]
+      mww $CLKDIS1_ADDR $TEMP_MOD
+
+      # Reset the SPI peripheral
+      mww $PERRST_ADDR 0x18
+
+      # Setup the SPI flash GPIO pins to AF1
+      # Set en0, en1, and en2 registers to 0
+
+      set TEMP [mrw $GPIO1_EN_ADDR]
+      set TEMP_MOD [expr { $TEMP & $GPIO1_SPI_MASK} ]
+      mww $GPIO1_EN_ADDR $TEMP_MOD
+
+      set TEMP [mrw $GPIO1_EN1_ADDR]
+      set TEMP_MOD [expr { $TEMP & $GPIO1_SPI_MASK} ]
+      mww $GPIO1_EN1_ADDR $TEMP_MOD
+
+      set TEMP [mrw $GPIO1_EN2_ADDR]
+      set TEMP_MOD [expr { $TEMP & $GPIO1_SPI_MASK} ]
+      mww $GPIO1_EN2_ADDR $TEMP_MOD
+
+      # Set the HOLD/RST and WP lines high
+      set TEMP [mrw $GPIO1_EN_ADDR]
+      set TEMP_MOD [expr { $TEMP | $GPIO1_RST_MASK} ]
+      mww $GPIO1_EN_ADDR $TEMP_MOD
+
+      set TEMP [mrw $GPIO1_OUT_EN_ADDR]
+      set TEMP_MOD [expr { $TEMP | $GPIO1_RST_MASK} ]
+      mww $GPIO1_OUT_EN_ADDR $TEMP_MOD
+      mww $GPIO1_OUT_SET_ADDR $GPIO1_RST_MASK
+
+      # Max drive strength
+      set TEMP [mrw $GPIO1_DS0_ADDR]
+      set TEMP_MOD [expr { $TEMP | $GPIO1_RST_MASK | ~($GPIO1_SPI_MASK) } ]
+      mww $GPIO1_DS0_ADDR $TEMP_MOD
+
+      set TEMP [mrw $GPIO1_DS0_ADDR]
+      set TEMP_MOD [expr { $TEMP | $GPIO1_RST_MASK | ~($GPIO1_SPI_MASK) } ]
+      mww $GPIO1_DS1_ADDR $TEMP_MOD
+
+      set TEMP [mrw $GPIO1_VSSEL_ADDR]
+      set TEMP_MOD [expr { $TEMP | $GPIO1_RST_MASK | ~($GPIO1_SPI_MASK) } ]
+
+      if {$QSPI_VDDIOH != 0} {
+        # Use VDDIOH
+        mww $GPIO1_VSSEL_ADDR $TEMP_MOD
+      } else {
+        # Use VDDIO
+        mww $GPIO1_VSSEL_ADDR [expr { !($TEMP_MOD) } ]
+      }
+
+      # Finish setting up the QSPI, 2 is the flash bank id for the qspi driver
+      max32xxx_qspi reset_deassert 2
+    }
+
+    $_CHIPNAME.cpu configure -event examine-end {
+      init_spi
+    }
+
+    $_CHIPNAME.cpu configure -event reset-deassert-post {
+      init_spi
+    }
+}

--- a/tcl/target/max32625.cfg
+++ b/tcl/target/max32625.cfg
@@ -1,28 +1,21 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 # Maxim Integrated MAX32625 OpenOCD target configuration file
 # www.maximintegrated.com
 
-# adapter speed
-adapter speed 4000
-
-# reset pin configuration
+# Set the reset pin configuration
 reset_config srst_only
+adapter srst delay 200
 
-if {[using_jtag]} {
-    jtag newtap max32625 cpu -irlen 4 -irmask 0xf -expected-id 0x4ba00477 -ignore-version
-    jtag newtap maxtest tap -irlen 4 -irmask 0xf -ircapture 0x1 -expected-id 0x07f71197 -ignore-version
-} else {
-    swd newdap max32625 cpu -irlen 4 -irmask 0xf -expected-id 0x2ba01477 -ignore-version
-}
+# Set flash parameters
+set FLASH_BASE 0x0
+set FLASH_SIZE 0x80000
+set FLC_BASE 0x40002000
+set FLASH_SECTOR 0x2000
+set FLASH_CLK 96
+set FLASH_OPTIONS 0x00
 
-# target configuration
-target create max32625.cpu cortex_m -chain-position max32625.cpu
-max32625.cpu configure -work-area-phys 0x20005000 -work-area-size 0x2000
+# Setup the reserved TAP
+set RSV_TAP 1
 
-# Config Command: flash bank name driver base size chip_width bus_width target [driver_options]
-#   flash bank <name> max32xxx <base> <size> 0 0 <target> <flc base> <sector> <clk> <burst>
-#   max32625 flash base address   0x00000000
-#   max32625 flash size           0x80000 (512k)
-#   max32625 FLC base address     0x40002000
-#   max32625 sector (page) size   0x2000 (8kB)
-#   max32625 clock speed          96 (MHz)
-flash bank max32625.flash max32xxx 0x00000000 0x80000 0 0 max32625.cpu 0x40002000 0x2000 96
+source [find target/max32xxx.cfg]

--- a/tcl/target/max3263x.cfg
+++ b/tcl/target/max3263x.cfg
@@ -1,28 +1,41 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 # Maxim Integrated MAX3263X OpenOCD target configuration file
 # www.maximintegrated.com
 
-# adapter speed
-adapter speed 4000
+# Set the reset pin configuration
+reset_config none
 
-# reset pin configuration
-reset_config srst_only
+# Set flash parameters
+set FLASH_BASE 0x0
+set FLASH_SIZE 0x200000
+set FLC_BASE 0x40002000
+set FLASH_SECTOR 0x2000
+set FLASH_CLK 96
+set FLASH_OPTIONS 0x00
 
-if {[using_jtag]} {
-    jtag newtap max3263x cpu -irlen 4 -irmask 0xf -expected-id 0x4ba00477 -ignore-version
-    jtag newtap maxtest tap -irlen 4 -irmask 0xf -ircapture 0x1 -expected-id 0x07f76197 -ignore-version
-} else {
-    swd newdap max3263x cpu -irlen 4 -irmask 0xf -expected-id 0x2ba01477 -ignore-version
+# Setup the reserved TAP
+set RSV_TAP 1
+
+source [find target/max32xxx.cfg]
+
+# Create custom reset sequence
+$_CHIPNAME.cpu configure -event reset-init {
+
+    # Reset the peripherals
+    mww 0x40000848 0xFFFFFFFF
+    mww 0x4000084C 0xFFFFFFFF
+
+    sleep 10
+
+    mww 0x40000848 0x0
+    mww 0x4000084C 0x0
+
+    # Reset the SP
+    set SP_ADDR [mrw 0x0]
+    reg sp $SP_ADDR
+
+    # Reset the PC to the Reset_Handler
+    set RESET_HANDLER_ADDR  [mrw 0x4]
+    reg pc $RESET_HANDLER_ADDR
 }
-
-# target configuration
-target create max3263x.cpu cortex_m -chain-position max3263x.cpu
-max3263x.cpu configure -work-area-phys 0x20005000 -work-area-size 0x2000
-
-# Config Command: flash bank name driver base size chip_width bus_width target [driver_options]
-#   flash bank <name> max32xxx <base> <size> 0 0 <target> <flc base> <sector> <clk> <burst>
-#   max3263x flash base address   0x00000000
-#   max3263x flash size           0x200000 (2MB)
-#   max3263x FLC base address     0x40002000
-#   max3263x sector (page) size   0x2000 (8kB)
-#   max3263x clock speed          96 (MHz)
-flash bank max3263x.flash max32xxx 0x00000000 0x200000 0 0 max3263x.cpu 0x40002000 0x2000 96

--- a/tcl/target/max32650.cfg
+++ b/tcl/target/max32650.cfg
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-
-# Maxim Integrated MAX32620 OpenOCD target configuration file
+# Maxim Integrated MAX32650 OpenOCD target configuration file
 # www.maximintegrated.com
 
 # Set the reset pin configuration
@@ -8,14 +7,11 @@ reset_config srst_only
 adapter srst delay 200
 
 # Set flash parameters
-set FLASH_BASE 0x0
-set FLASH_SIZE 0x200000
-set FLC_BASE 0x40002000
+set FLASH_BASE 0x10000000
+set FLASH_SIZE 0x300000
+set FLC_BASE 0x40029000
 set FLASH_SECTOR 0x2000
 set FLASH_CLK 96
 set FLASH_OPTIONS 0x00
-
-# Setup the reserved TAP
-set RSV_TAP 1
 
 source [find target/max32xxx.cfg]

--- a/tcl/target/max32655.cfg
+++ b/tcl/target/max32655.cfg
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Maxim Integrated MAX32655 OpenOCD target configuration file
+# www.maximintegrated.com
+
+# Set the reset pin configuration
+reset_config srst_only
+adapter srst delay 2
+adapter srst pulse_width 2
+
+# Set flash parameters
+set FLASH_BASE 0x10000000
+set FLASH_SIZE 0x80000
+set FLC_BASE 0x40029000
+set FLASH_SECTOR 0x2000
+set FLASH_CLK 100
+set FLASH_OPTIONS 0x01
+
+# Use Serial Wire Debug
+transport select swd
+
+source [find target/max32xxx.cfg]

--- a/tcl/target/max32655_riscv.cfg
+++ b/tcl/target/max32655_riscv.cfg
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Maxim Integrated MAX32655 OpenOCD target configuration file
+# www.maximintegrated.com
+
+# Set the reset pin configuration
+reset_config srst_only
+
+# set reset delay so ARM core can re-enable RISCV debugger pins
+adapter srst delay 100
+
+adapter speed 4000
+
+# Set flash parameters
+set FLASH_BASE 0x10000000
+set FLASH_SIZE 0x80000
+set FLC_BASE 0x40029000
+set FLASH_SECTOR 0x2000
+set FLASH_CLK 96
+set FLASH_OPTIONS 0x01
+
+set CHIPNAME max32xxx_riscv
+
+jtag newtap $CHIPNAME cpu -irlen 4 -irmask 0xf -ircapture 0x5 -expected-id 0x16210197 -ignore-version
+target create $CHIPNAME.cpu rvmax -chain-position $CHIPNAME.cpu
+
+$CHIPNAME.cpu configure -work-area-phys 0x20010000 -work-area-size 0x1000
+
+# Enable thread-aware debugging
+$CHIPNAME.cpu configure -rtos auto
+
+flash bank $CHIPNAME.flash max32xxx $FLASH_BASE $FLASH_SIZE 0 0 $CHIPNAME.cpu $FLC_BASE $FLASH_SECTOR $FLASH_CLK $FLASH_OPTIONS
+
+$CHIPNAME.cpu configure -event reset-end {
+    # Set the PC to the load address where the interrupt vector is stored
+    reg pc Reset_Handler
+}

--- a/tcl/target/max32660.cfg
+++ b/tcl/target/max32660.cfg
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-
-# Maxim Integrated MAX32620 OpenOCD target configuration file
+# Maxim Integrated MAX32660 OpenOCD target configuration file
 # www.maximintegrated.com
 
 # Set the reset pin configuration
@@ -9,13 +8,10 @@ adapter srst delay 200
 
 # Set flash parameters
 set FLASH_BASE 0x0
-set FLASH_SIZE 0x200000
-set FLC_BASE 0x40002000
+set FLASH_SIZE 0x40000
+set FLC_BASE 0x40029000
 set FLASH_SECTOR 0x2000
 set FLASH_CLK 96
 set FLASH_OPTIONS 0x00
-
-# Setup the reserved TAP
-set RSV_TAP 1
 
 source [find target/max32xxx.cfg]

--- a/tcl/target/max32662.cfg
+++ b/tcl/target/max32662.cfg
@@ -1,21 +1,21 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-
-# Maxim Integrated MAX32620 OpenOCD target configuration file
+# Maxim Integrated OpenOCD target configuration file
 # www.maximintegrated.com
 
 # Set the reset pin configuration
 reset_config srst_only
 adapter srst delay 200
+adapter srst pulse_width 200
 
 # Set flash parameters
-set FLASH_BASE 0x0
-set FLASH_SIZE 0x200000
-set FLC_BASE 0x40002000
+set FLASH_BASE 0x10000000
+set FLASH_SIZE 0x40000
+set FLC_BASE 0x40029000
 set FLASH_SECTOR 0x2000
 set FLASH_CLK 96
-set FLASH_OPTIONS 0x00
+set FLASH_OPTIONS 0x01
 
-# Setup the reserved TAP
-set RSV_TAP 1
+# Use Serial Wire Debug
+transport select swd
 
 source [find target/max32xxx.cfg]

--- a/tcl/target/max32665.cfg
+++ b/tcl/target/max32665.cfg
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Maxim Integrated MAX32665 OpenOCD target configuration file
+# www.maximintegrated.com
+
+# Set the reset pin configuration
+reset_config srst_only
+adapter srst delay 200
+
+set CHIPNAME max32665
+
+# Set flash parameters
+set FLASH_BASE 0x10000000
+set FLASH_SIZE 0x80000
+set FLC_BASE 0x40029000
+set FLASH_SECTOR 0x2000
+set FLASH_CLK 96
+set FLASH_OPTIONS 0x01
+
+# Enable or disable QSPI driver
+set QSPI_ENABLE 0
+
+global QSPI_VDDIOH
+# 1: Run QSPI at VDDIOH (3.3V)
+# 0: Run QSPI at VDDIO  (1.8V)
+set QSPI_VDDIOH 0
+
+# Setup QSPI options
+set QSPI_ADDR_BASE 0x08000000
+set QSPI_ADDR_SIZE 0x0800000
+set QSPI_OPTIONS 0x0
+
+# Use Serial Wire Debug
+transport select swd
+
+source [find target/max32xxx.cfg]
+
+# Add additional flash bank
+set FLASH_BASE 0x10080000
+set FLC_BASE 0x40029400
+
+flash bank $_CHIPNAME.flash1 max32xxx $FLASH_BASE $FLASH_SIZE 0 0 $_CHIPNAME.cpu \
+$FLC_BASE $FLASH_SECTOR $FLASH_CLK $FLASH_OPTIONS
+
+if {$QSPI_ENABLE == 1} {
+
+    if {$QSPI_VDDIOH != 0} {
+      echo "Warning - using VDDIOH (3.3V) for QSPI"
+    }
+
+    # Initialize the flash bank
+    flash bank $_CHIPNAME.qspi_flash max32xxx_qspi $QSPI_ADDR_BASE $QSPI_ADDR_SIZE \
+      0 0 $_CHIPNAME.cpu $QSPI_OPTIONS
+
+    source [find mem_helper.tcl]
+
+    # Setup the hardware to use the QSPI peripheral
+    proc init_spi {} {
+
+      global QSPI_VDDIOH
+
+      set CLKDIS0_ADDR 0x40000024
+      set CLKDIS1_ADDR 0x40000048
+      set PERRST_ADDR 0x40000044
+
+      set GPIO0_EN_ADDR 0x40008000
+      set GPIO0_OUT_EN_ADDR 0x4000800C
+      set GPIO0_OUT_SET_ADDR 0x4000801C
+      set GPIO0_EN1_ADDR 0x40008068
+      set GPIO0_EN2_ADDR 0x40008074
+      set GPIO0_DS0_ADDR 0x400080B0
+      set GPIO0_DS1_ADDR 0x400080B4
+      set GPIO0_VSSEL_ADDR 0x400080C0
+
+      set GPIO0_SPI_MASK 0xFFFFFFC0
+      set GPIO0_RST_MASK 0x00000030
+
+      # Enable SPI and GPIO0 clocks
+      set TEMP [mrw $CLKDIS0_ADDR]
+      set TEMP_MOD [expr { $TEMP & 0x3FFFFFF8} ]
+      mww $CLKDIS0_ADDR $TEMP_MOD
+
+      # Enable the SPI XIP cache
+      set TEMP [mrw $CLKDIS1_ADDR]
+      set TEMP_MOD [expr { $TEMP & 0xFFFFE7FF} ]
+      mww $CLKDIS1_ADDR $TEMP_MOD
+
+      # Reset the SPI peripheral
+      mww $PERRST_ADDR 0x18
+
+      # Setup the SPI flash GPIO pins to AF1
+      # Set en0, en1, and en2 registers to 0
+
+      set TEMP [mrw $GPIO0_EN_ADDR]
+      set TEMP_MOD [expr { $TEMP & $GPIO0_SPI_MASK} ]
+      mww $GPIO0_EN_ADDR $TEMP_MOD
+
+      set TEMP [mrw $GPIO0_EN1_ADDR]
+      set TEMP_MOD [expr { $TEMP & $GPIO0_SPI_MASK} ]
+      mww $GPIO0_EN1_ADDR $TEMP_MOD
+
+      set TEMP [mrw $GPIO0_EN2_ADDR]
+      set TEMP_MOD [expr { $TEMP & $GPIO0_SPI_MASK} ]
+      mww $GPIO0_EN2_ADDR $TEMP_MOD
+
+      # Set the HOLD/RST and WP lines high
+      set TEMP [mrw $GPIO0_EN_ADDR]
+      set TEMP_MOD [expr { $TEMP | $GPIO0_RST_MASK} ]
+      mww $GPIO0_EN_ADDR $TEMP_MOD
+
+      set TEMP [mrw $GPIO0_OUT_EN_ADDR]
+      set TEMP_MOD [expr { $TEMP | $GPIO0_RST_MASK} ]
+      mww $GPIO0_OUT_EN_ADDR $TEMP_MOD
+      mww $GPIO0_OUT_SET_ADDR $GPIO0_RST_MASK
+
+      # Max drive strength
+      set TEMP [mrw $GPIO0_DS0_ADDR]
+      set TEMP_MOD [expr { $TEMP | $GPIO0_RST_MASK | ~($GPIO0_SPI_MASK) } ]
+      mww $GPIO0_DS0_ADDR $TEMP_MOD
+
+      set TEMP [mrw $GPIO0_DS0_ADDR]
+      set TEMP_MOD [expr { $TEMP | $GPIO0_RST_MASK | ~($GPIO0_SPI_MASK) } ]
+      mww $GPIO0_DS1_ADDR $TEMP_MOD
+
+      set TEMP [mrw $GPIO0_VSSEL_ADDR]
+      set TEMP_MOD [expr { $TEMP | $GPIO0_RST_MASK | ~($GPIO0_SPI_MASK) } ]
+
+      if {$QSPI_VDDIOH != 0} {
+        # Use VDDIOH
+        mww $GPIO0_VSSEL_ADDR $TEMP_MOD
+      } else {
+        # Use VDDIO
+        mww $GPIO0_VSSEL_ADDR [expr { !($TEMP_MOD) } ]
+      }
+
+      # Finish setting up the QSPI, 2 is the flash bank id for the qspi driver
+      max32xxx_qspi reset_deassert 2
+    }
+
+    $_CHIPNAME.cpu configure -event examine-end {
+      init_spi
+    }
+
+    $_CHIPNAME.cpu configure -event reset-deassert-post {
+      init_spi
+    }
+}

--- a/tcl/target/max32665_nsrst.cfg
+++ b/tcl/target/max32665_nsrst.cfg
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Maxim Integrated MAX32665 OpenOCD target configuration file
+# www.maximintegrated.com
+
+# Set the reset pin configuration
+reset_config none separate
+adapter_nsrst_delay 300
+
+# Set flash parameters
+set FLASH_BASE 0x10000000
+set FLASH_SIZE 0x80000
+set FLC_BASE 0x40029000
+set FLASH_SECTOR 0x2000
+set FLASH_CLK 96
+set FLASH_OPTIONS 0x01
+
+# Use Serial Wire Debug
+transport select swd
+
+source [find target/max32xxx.cfg]
+
+# Add additional flash bank
+set FLASH_BASE 0x10080000
+set FLC_BASE 0x40029400
+
+flash bank $_CHIPNAME.flash1 max32xxx $FLASH_BASE $FLASH_SIZE 0 0 $_CHIPNAME.cpu \
+$FLC_BASE $FLASH_SECTOR $FLASH_CLK $FLASH_OPTIONS
+

--- a/tcl/target/max32670.cfg
+++ b/tcl/target/max32670.cfg
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# maxim Integrated OpenOCD target configuration file
+# www.maximintegrated.com
+
+# reset pin configuration
+reset_config none
+adapter_nsrst_delay 200
+adapter_nsrst_assert_width 200
+
+# Set flash parameters
+set FLASH_BASE 0x10000000
+set FLASH_SIZE 0x60000
+set FLC_BASE 0x40029000
+set FLASH_SECTOR 0x2000
+set FLASH_CLK 96
+set FLASH_OPTIONS 0x01
+
+# Use Serial Wire Debug
+transport select swd
+
+source [find target/max32xxx.cfg]
+
+global rom_bp_enabled
+set rom_bp_enabled "no"
+
+# Override default init_reset{mode} to catch parameter "mode"
+proc init_reset {mode} {
+	global sp_reset_mode
+	set sp_reset_mode $mode
+}
+
+$_CHIPNAME.cpu configure -event reset-deassert-post {
+  global sp_reset_mode
+  global _CHIPNAME
+
+	if { ([string compare $sp_reset_mode "init"] == 0) } {
+    set state "reset"
+    while { [string compare $state "reset"] == 0 } {
+      set state [$_CHIPNAME.cpu curstate]
+      $_CHIPNAME.cpu arp_poll
+      }
+    $_CHIPNAME.cpu arp_halt
+  }
+}
+
+$_CHIPNAME.cpu configure -event reset-assert-pre {
+  global sp_reset_mode
+  global rom_bp_enabled
+
+  if { (([string compare $sp_reset_mode "halt"] == 0) || ([string compare $sp_reset_mode "init"] == 0)) } {
+    halt
+   	if { ([string compare $rom_bp_enabled "yes"] == 0) } {
+      rbp 0x00002174
+      }
+    bp 0x00002174 2 hw
+    set rom_bp_enabled "yes"
+  }
+}
+
+$_CHIPNAME.cpu configure -event halted {
+  global sp_reset_mode
+  global rom_bp_enabled
+
+	if { ([string compare $rom_bp_enabled "yes"] == 0) } {
+    rbp 0x00002174
+    set rom_bp_enabled "no"
+  }
+  set sp_reset_mode none
+}

--- a/tcl/target/max32672.cfg
+++ b/tcl/target/max32672.cfg
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# maxim Integrated OpenOCD target configuration file
+# www.maximintegrated.com
+
+# reset pin configuration
+reset_config none
+adapter_nsrst_delay 200
+adapter_nsrst_assert_width 200
+
+# Set flash parameters
+set FLASH_BASE 0x10000000
+set FLASH_SIZE 0x80000
+set FLC_BASE 0x40029000
+set FLASH_SECTOR 0x2000
+set FLASH_CLK 96
+set FLASH_OPTIONS 0x01
+
+# Use Serial Wire Debug
+transport select swd
+
+source [find target/max32xxx.cfg]
+
+# Add additional flash bank
+set FLASH_BASE 0x10080000
+set FLC_BASE 0x40029400
+
+flash bank $_CHIPNAME.flash1 max32xxx $FLASH_BASE $FLASH_SIZE 0 0 $_CHIPNAME.cpu \
+$FLC_BASE $FLASH_SECTOR $FLASH_CLK $FLASH_OPTIONS
+

--- a/tcl/target/max32675.cfg
+++ b/tcl/target/max32675.cfg
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# maxim Integrated OpenOCD target configuration file
+# www.maximintegrated.com
+
+# reset pin configuration
+reset_config none
+adapter_nsrst_delay 200
+adapter_nsrst_assert_width 200
+
+# Set flash parameters
+set FLASH_BASE 0x10000000
+set FLASH_SIZE 0x60000
+set FLC_BASE 0x40029000
+set FLASH_SECTOR 0x2000
+set FLASH_CLK 96
+set FLASH_OPTIONS 0x01
+
+# Use Serial Wire Debug
+transport select swd
+
+source [find target/max32xxx.cfg]
+
+global rom_bp_enabled
+set rom_bp_enabled "no"
+
+# Override default init_reset{mode} to catch parameter "mode"
+proc init_reset {mode} {
+	global sp_reset_mode
+	set sp_reset_mode $mode
+}
+
+$_CHIPNAME.cpu configure -event reset-deassert-post {
+  global sp_reset_mode
+  global _CHIPNAME
+
+	if { ([string compare $sp_reset_mode "init"] == 0) } {
+    set state "reset"
+    while { [string compare $state "reset"] == 0 } {
+      set state [$_CHIPNAME.cpu curstate]
+      $_CHIPNAME.cpu arp_poll
+      }
+    $_CHIPNAME.cpu arp_halt
+  }
+}
+
+$_CHIPNAME.cpu configure -event reset-assert-pre {
+  global sp_reset_mode
+  global rom_bp_enabled
+
+  if { (([string compare $sp_reset_mode "halt"] == 0) || ([string compare $sp_reset_mode "init"] == 0)) } {
+    halt
+   	if { ([string compare $rom_bp_enabled "yes"] == 0) } {
+      rbp 0x00002174
+      }
+    bp 0x00002174 2 hw
+    set rom_bp_enabled "yes"
+  }
+}
+
+$_CHIPNAME.cpu configure -event halted {
+  global sp_reset_mode
+  global rom_bp_enabled
+
+	if { ([string compare $rom_bp_enabled "yes"] == 0) } {
+    rbp 0x00002174
+    set rom_bp_enabled "no"
+  }
+  set sp_reset_mode none
+}

--- a/tcl/target/max32680.cfg
+++ b/tcl/target/max32680.cfg
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Maxim Integrated MAX32655 OpenOCD target configuration file
+# www.maximintegrated.com
+
+adapter speed 500
+
+# Set the reset pin configuration
+reset_config srst_only
+adapter srst delay 2
+adapter srst pulse_width 2
+
+# Set flash parameters
+set FLASH_BASE 0x10000000
+set FLASH_SIZE 0x80000
+set FLC_BASE 0x40029000
+set FLASH_SECTOR 0x2000
+set FLASH_CLK 100
+set FLASH_OPTIONS 0x01
+
+# Use Serial Wire Debug
+transport select swd
+
+source [find target/max32xxx.cfg]

--- a/tcl/target/max32680_riscv.cfg
+++ b/tcl/target/max32680_riscv.cfg
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# MAX32680 RISC-V core OpenOCD configuration
+# www.analog.com
+
+# Set the reset pin configuration
+reset_config srst_only
+
+# set reset delay so ARM core can re-enable RISCV debugger pins
+adapter srst delay 100
+
+adapter speed 4000
+
+# Set flash parameters
+set FLASH_BASE 0x10000000
+set FLASH_SIZE 0x80000
+set FLC_BASE 0x40029000
+set FLASH_SECTOR 0x2000
+set FLASH_CLK 100
+set FLASH_OPTIONS 0x01
+
+set CHIPNAME max32xxx_riscv
+
+jtag newtap $CHIPNAME cpu -irlen 4 -irmask 0xf -ircapture 0x5 -expected-id 0x16210197 -ignore-version
+target create $CHIPNAME.cpu rvmax -chain-position $CHIPNAME.cpu
+
+$CHIPNAME.cpu configure -work-area-phys 0x20010000 -work-area-size 0x1000
+
+# Enable thread-aware debugging
+$CHIPNAME.cpu configure -rtos auto
+
+flash bank $CHIPNAME.flash max32xxx $FLASH_BASE $FLASH_SIZE 0 0 $CHIPNAME.cpu $FLC_BASE $FLASH_SECTOR $FLASH_CLK $FLASH_OPTIONS
+
+$CHIPNAME.cpu configure -event reset-end {
+    # Set the PC to the load address where the interrupt vector is stored
+    reg pc Reset_Handler
+}

--- a/tcl/target/max32690.cfg
+++ b/tcl/target/max32690.cfg
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Maxim Integrated MAX32690 OpenOCD target configuration file
+# www.maximintegrated.com
+
+# Set the reset pin configuration
+reset_config srst_only
+adapter srst delay 2
+adapter srst pulse_width 2
+
+# Set flash parameters
+set FLASH_BASE 0x10000000
+set FLASH_SIZE 0x300000
+set FLC_BASE 0x40029000
+set FLASH_SECTOR 0x4000
+set FLASH_CLK 60
+set FLASH_OPTIONS 0x01
+
+# Use Serial Wire Debug
+transport select swd
+
+source [find target/max32xxx.cfg]
+
+# Add additional flash bank
+set FLASH_BASE 0x10300000
+set FLASH_SIZE 0x40000
+set FLC_BASE 0x40029400
+set FLASH_SECTOR 0x2000
+
+flash bank $_CHIPNAME.flash1 max32xxx $FLASH_BASE $FLASH_SIZE 0 0 $_CHIPNAME.cpu \
+$FLC_BASE $FLASH_SECTOR $FLASH_CLK $FLASH_OPTIONS
+
+global rom_bp_enabled
+set rom_bp_enabled "no"
+
+# Override default init_reset{mode} to catch parameter "mode"
+proc init_reset {mode} {
+	global sp_reset_mode
+	set sp_reset_mode $mode
+}
+
+$_CHIPNAME.cpu configure -event reset-deassert-post {
+  global sp_reset_mode
+  global _CHIPNAME
+
+	if { ([string compare $sp_reset_mode "init"] == 0) } {
+    set state "reset"
+    while { [string compare $state "reset"] == 0 } {
+      set state [$_CHIPNAME.cpu curstate]
+      $_CHIPNAME.cpu arp_poll
+      }
+    $_CHIPNAME.cpu arp_halt
+  }
+}
+
+$_CHIPNAME.cpu configure -event reset-assert-pre {
+  global sp_reset_mode
+  global rom_bp_enabled
+
+  if { (([string compare $sp_reset_mode "halt"] == 0) || ([string compare $sp_reset_mode "init"] == 0)) } {
+    halt
+   	if { ([string compare $rom_bp_enabled "yes"] == 0) } {
+      rbp 0x0000FFF4
+      }
+    bp 0x0000FFF4 2 hw
+    set rom_bp_enabled "yes"
+  }
+}
+
+$_CHIPNAME.cpu configure -event halted {
+  global sp_reset_mode
+  global rom_bp_enabled
+
+	if { ([string compare $rom_bp_enabled "yes"] == 0) } {
+    rbp 0x0000FFF4
+    set rom_bp_enabled "no"
+  }
+  set sp_reset_mode none
+}

--- a/tcl/target/max32690_riscv.cfg
+++ b/tcl/target/max32690_riscv.cfg
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# MAX32690 RISC-V core OpenOCD configuration
+# www.analog.com
+
+# Set the reset pin configuration
+reset_config srst_only
+
+# set reset delay so ARM core can re-enable RISCV debugger pins
+adapter srst delay 100
+
+adapter speed 4000
+
+set CHIPNAME max32xxx_riscv
+
+# Set flash parameters
+set FLASH_BASE 0x10000000
+set FLASH_SIZE 0x300000
+set FLC_BASE 0x40029000
+set FLASH_SECTOR 0x4000
+set FLASH_CLK 60
+set FLASH_OPTIONS 0x01
+
+flash bank $CHIPNAME.flash max32xxx $FLASH_BASE $FLASH_SIZE 0 0 $CHIPNAME.cpu $FLC_BASE $FLASH_SECTOR $FLASH_CLK $FLASH_OPTIONS
+
+# Add additional flash bank
+set FLASH_BASE 0x10300000
+set FLASH_SIZE 0x40000
+set FLC_BASE 0x40029400
+set FLASH_SECTOR 0x2000
+
+flash bank $CHIPNAME.flash1 max32xxx $FLASH_BASE $FLASH_SIZE 0 0 $_CHIPNAME.cpu $FLC_BASE $FLASH_SECTOR $FLASH_CLK $FLASH_OPTIONS
+
+jtag newtap $CHIPNAME cpu -irlen 4 -irmask 0xf -ircapture 0x5 -expected-id 0x16210197 -ignore-version
+target create $CHIPNAME.cpu rvmax -chain-position $CHIPNAME.cpu
+
+$CHIPNAME.cpu configure -work-area-phys 0x20010000 -work-area-size 0x1000
+
+# Enable thread-aware debugging
+$CHIPNAME.cpu configure -rtos auto
+
+$CHIPNAME.cpu configure -event reset-end {
+    # Set the PC to the load address where the interrupt vector is stored
+    reg pc Reset_Handler
+}

--- a/tcl/target/max32xxx.cfg
+++ b/tcl/target/max32xxx.cfg
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Maxim Integrated max32xxx OpenOCD drver configuration file
+# www.maximintegrated.com
+
+source [find mem_helper.tcl]
+source [find target/swj-dp.tcl]
+
+# Set the adapter speed
+if { [info exists ADAPTER_KHZ] } {
+   set _ADAPTER_KHZ $ADAPTER_KHZ
+} else {
+   set _ADAPTER_KHZ 2000
+}
+adapter speed $_ADAPTER_KHZ
+
+# Target configuration
+if { [info exists CHIPNAME] } {
+   set _CHIPNAME $CHIPNAME
+} else {
+   set _CHIPNAME max32xxx
+}
+
+# Add reserved TAP
+if { [using_jtag] && [info exists RSV_TAP] } {
+   jtag newtap $_CHIPNAME cpu -irlen 4 -ircapture 0x1 -irmask 0xf -ignore-version
+   jtag newtap rsvtap tap -irlen 4 -irmask 0xf -ircapture 0x1 -ignore-version
+} else {
+   swj_newdap $_CHIPNAME cpu -irlen 4 -ircapture 0x1 -irmask 0xf -ignore-version
+}
+
+
+dap create $_CHIPNAME.dap -chain-position $_CHIPNAME.cpu
+target create $_CHIPNAME.cpu cortex_m -dap $_CHIPNAME.dap
+
+# Enable thread-aware debugging
+$_CHIPNAME.cpu configure -rtos auto
+
+# Setup working area
+if { [info exists WORK_START] } {
+   set _WORK_START $WORK_START
+} else {
+   set _WORK_START 0x20005000
+}
+
+if { [info exists WORK_SIZE] } {
+   set _WORK_SIZE $WORK_SIZE
+} else {
+   set _WORK_SIZE 0x8000
+}
+
+$_CHIPNAME.cpu configure -work-area-phys $_WORK_START -work-area-size $_WORK_SIZE
+
+# Configure flash driver
+if { [info exists FLASH_BASE] } {
+   set _FLASH_BASE $FLASH_BASE
+} else {
+   set _FLASH_BASE 0x10000000
+}
+
+if { [info exists FLASH_SIZE] } {
+   set _FLASH_SIZE $FLASH_SIZE
+} else {
+   set _FLASH_SIZE 0x10000
+}
+
+if { [info exists FLC_BASE] } {
+   set _FLC_BASE $FLC_BASE
+} else {
+   set _FLC_BASE 0x40029000
+}
+
+if { [info exists FLASH_SECTOR] } {
+   set _FLASH_SECTOR $FLASH_SECTOR
+} else {
+   set _FLASH_SECTOR 0x2000
+}
+
+if { [info exists FLASH_CLK] } {
+   set _FLASH_CLK $FLASH_CLK
+} else {
+   set _FLASH_CLK 96
+}
+
+# OPTIONS_128                     0x01 /* Perform 128 bit flash writes */
+# OPTIONS_ENC                     0x02 /* Encrypt the flash contents */
+# OPTIONS_AUTH                    0x04 /* Authenticate the flash contents */
+# OPTIONS_COUNT                   0x08 /* Add counter values to authentication */
+# OPTIONS_INTER                   0x10 /* Interleave the authentication and count values*/
+# OPTIONS_RELATIVE_XOR            0x20 /* Only XOR the offset of the address when encrypting */
+# OPTIONS_KEYSIZE                 0x40 /* Use a 256 bit KEY */
+
+if { [info exists FLASH_OPTIONS] } {
+   set _FLASH_OPTIONS $FLASH_OPTIONS
+} else {
+   set _FLASH_OPTIONS 0
+}
+
+flash bank $_CHIPNAME.flash max32xxx $_FLASH_BASE $_FLASH_SIZE 0 0 $_CHIPNAME.cpu \
+$_FLC_BASE $_FLASH_SECTOR $_FLASH_CLK $_FLASH_OPTIONS

--- a/tcl/target/max78000.cfg
+++ b/tcl/target/max78000.cfg
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Maxim Integrated MAX78000 OpenOCD target configuration file
+# www.maximintegrated.com
+
+adapter speed 500
+
+# Set the reset pin configuration
+reset_config srst_only
+adapter srst delay 2
+adapter srst pulse_width 2
+
+# Set flash parameters
+set FLASH_BASE 0x10000000
+set FLASH_SIZE 0x80000
+set FLC_BASE 0x40029000
+set FLASH_SECTOR 0x2000
+set FLASH_CLK 100
+set FLASH_OPTIONS 0x01
+
+# Use Serial Wire Debug
+transport select swd
+
+source [find target/max32xxx.cfg]
+
+global rom_bp_enabled
+set rom_bp_enabled "no"
+
+# Override default init_reset{mode} to catch parameter "mode"
+proc init_reset {mode} {
+	global sp_reset_mode
+	set sp_reset_mode $mode
+}
+
+$_CHIPNAME.cpu configure -event reset-deassert-post {
+	global sp_reset_mode
+	global _CHIPNAME
+
+	if { ([string compare $sp_reset_mode "init"] == 0) } {
+		set state "reset"
+		while { [string compare $state "reset"] == 0 } {
+			set state [$_CHIPNAME.cpu curstate]
+			$_CHIPNAME.cpu arp_poll
+		}
+		$_CHIPNAME.cpu arp_halt
+	}
+}
+
+$_CHIPNAME.cpu configure -event reset-assert-pre {
+	global sp_reset_mode
+	global rom_bp_enabled
+
+	if { (([string compare $sp_reset_mode "halt"] == 0) || ([string compare $sp_reset_mode "init"] == 0)) } {
+		catch {halt}
+		if { ([string compare $rom_bp_enabled "yes"] == 0) } {
+			rbp 0x00002124
+		}
+		bp 0x00002124 2 hw
+		set rom_bp_enabled "yes"
+	}
+}
+
+$_CHIPNAME.cpu configure -event halted {
+	global sp_reset_mode
+	global rom_bp_enabled
+
+	if { ([string compare $rom_bp_enabled "yes"] == 0) } {
+		rbp 0x00002124
+		set rom_bp_enabled "no"
+	}
+	set sp_reset_mode none
+}

--- a/tcl/target/max78000_nsrst.cfg
+++ b/tcl/target/max78000_nsrst.cfg
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Maxim Integrated MAX78000 OpenOCD target configuration file
+# www.maximintegrated.com
+
+adapter speed 500
+
+# Set the reset pin configuration
+reset_config none separate
+adapter_nsrst_delay 2
+adapter srst pulse_width 2
+
+# Set flash parameters
+set FLASH_BASE 0x10000000
+set FLASH_SIZE 0x80000
+set FLC_BASE 0x40029000
+set FLASH_SECTOR 0x2000
+set FLASH_CLK 100
+set FLASH_OPTIONS 0x01
+
+# Use Serial Wire Debug
+transport select swd
+
+source [find target/max32xxx.cfg]
+
+global rom_bp_enabled
+set rom_bp_enabled "no"
+
+# Override default init_reset{mode} to catch parameter "mode"
+proc init_reset {mode} {
+    global sp_reset_mode
+    set sp_reset_mode $mode
+}
+
+$_CHIPNAME.cpu configure -event reset-deassert-post {
+    global sp_reset_mode
+    global _CHIPNAME
+
+    if { ([string compare $sp_reset_mode "init"] == 0) } {
+        set state "reset"
+        while { [string compare $state "reset"] == 0 } {
+            set state [$_CHIPNAME.cpu curstate]
+            $_CHIPNAME.cpu arp_poll
+        }
+        $_CHIPNAME.cpu arp_halt
+    }
+}
+
+$_CHIPNAME.cpu configure -event reset-assert-pre {
+    global sp_reset_mode
+    global rom_bp_enabled
+
+    if { (([string compare $sp_reset_mode "halt"] == 0) || ([string compare $sp_reset_mode "init"] == 0)) } {
+        catch {halt}
+        if { ([string compare $rom_bp_enabled "yes"] == 0) } {
+            rbp 0x00002124
+        }
+        bp 0x00002124 2 hw
+        set rom_bp_enabled "yes"
+    }
+}
+
+$_CHIPNAME.cpu configure -event halted {
+    global sp_reset_mode
+    global rom_bp_enabled
+
+    if { ([string compare $rom_bp_enabled "yes"] == 0) } {
+        rbp 0x00002124
+        set rom_bp_enabled "no"
+    }
+    set sp_reset_mode none
+}

--- a/tcl/target/max78000_riscv.cfg
+++ b/tcl/target/max78000_riscv.cfg
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# MAX78000 RISC-V core OpenOCD configuration
+# www.analog.com
+
+# Set the reset pin configuration
+reset_config srst_only
+
+# set reset delay so ARM core can re-enable RISCV debugger pins
+adapter srst delay 100
+
+adapter speed 4000
+
+# Set flash parameters
+set FLASH_BASE 0x10000000
+set FLASH_SIZE 0x80000
+set FLC_BASE 0x40029000
+set FLASH_SECTOR 0x2000
+set FLASH_CLK 100
+set FLASH_OPTIONS 0x01
+
+set CHIPNAME max32xxx_riscv
+
+jtag newtap $CHIPNAME cpu -irlen 4 -irmask 0xf -ircapture 0x5 -expected-id 0x16210197 -ignore-version
+target create $CHIPNAME.cpu rvmax -chain-position $CHIPNAME.cpu
+
+$CHIPNAME.cpu configure -work-area-phys 0x20010000 -work-area-size 0x1000
+
+# Enable thread-aware debugging
+$CHIPNAME.cpu configure -rtos auto
+
+flash bank $CHIPNAME.flash max32xxx $FLASH_BASE $FLASH_SIZE 0 0 $CHIPNAME.cpu $FLC_BASE $FLASH_SECTOR $FLASH_CLK $FLASH_OPTIONS
+
+$CHIPNAME.cpu configure -event reset-end {
+    # Set the PC to the load address where the interrupt vector is stored
+    reg pc Reset_Handler
+}

--- a/tcl/target/max78002.cfg
+++ b/tcl/target/max78002.cfg
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Maxim Integrated MAX78002 OpenOCD target configuration file
+# www.maximintegrated.com
+
+adapter speed 500
+
+# Set the reset pin configuration
+reset_config srst_only
+adapter srst delay 2
+adapter srst pulse_width 2
+
+# Set flash parameters
+set FLASH_BASE 0x10000000
+set FLASH_SIZE 0x280000
+set FLC_BASE 0x40029000
+set FLASH_SECTOR 0x2000
+set FLASH_CLK 100
+set FLASH_OPTIONS 0x01
+
+# Use Serial Wire Debug
+transport select swd
+
+source [find target/max32xxx.cfg]
+
+global rom_bp_enabled
+set rom_bp_enabled "no"
+
+# Override default init_reset{mode} to catch parameter "mode"
+proc init_reset {mode} {
+  global sp_reset_mode
+  set sp_reset_mode $mode
+}
+
+$_CHIPNAME.cpu configure -event reset-deassert-post {
+  global sp_reset_mode
+  global _CHIPNAME
+
+  if { ([string compare $sp_reset_mode "init"] == 0) } {
+    set state "reset"
+    while { [string compare $state "reset"] == 0 } {
+      set state [$_CHIPNAME.cpu curstate]
+      $_CHIPNAME.cpu arp_poll
+    }
+    $_CHIPNAME.cpu arp_halt
+  }
+}
+
+$_CHIPNAME.cpu configure -event reset-assert-pre {
+  global sp_reset_mode
+  global rom_bp_enabled
+
+  if { (([string compare $sp_reset_mode "halt"] == 0) || ([string compare $sp_reset_mode "init"] == 0)) } {
+    catch {halt}
+    if { ([string compare $rom_bp_enabled "yes"] == 0) } {
+      rbp 0x0000FFF4
+    }
+    bp 0x0000FFF4 2 hw
+    set rom_bp_enabled "yes"
+  }
+}
+
+$_CHIPNAME.cpu configure -event halted {
+  global sp_reset_mode
+  global rom_bp_enabled
+
+  if { ([string compare $rom_bp_enabled "yes"] == 0) } {
+    rbp 0x0000FFF4
+    set rom_bp_enabled "no"
+  }
+  set sp_reset_mode none
+}

--- a/tcl/target/max78002_riscv.cfg
+++ b/tcl/target/max78002_riscv.cfg
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# MAX78002 RISC-V core OpenOCD configuration
+# www.analog.com
+
+# Set the reset pin configuration
+reset_config srst_only
+
+# set reset delay so ARM core can re-enable RISCV debugger pins
+adapter srst delay 100
+
+adapter speed 4000
+
+# Set flash parameters
+set FLASH_BASE 0x10000000
+set FLASH_SIZE 0x280000
+set FLC_BASE 0x40029000
+set FLASH_SECTOR 0x2000
+set FLASH_CLK 100
+set FLASH_OPTIONS 0x01
+
+set CHIPNAME max32xxx_riscv
+
+jtag newtap $CHIPNAME cpu -irlen 4 -irmask 0xf -ircapture 0x5 -expected-id 0x16210197 -ignore-version
+target create $CHIPNAME.cpu rvmax -chain-position $CHIPNAME.cpu
+
+$CHIPNAME.cpu configure -work-area-phys 0x20010000 -work-area-size 0x1000
+
+# Enable thread-aware debugging
+$CHIPNAME.cpu configure -rtos auto
+
+flash bank $CHIPNAME.flash max32xxx $FLASH_BASE $FLASH_SIZE 0 0 $CHIPNAME.cpu $FLC_BASE $FLASH_SECTOR $FLASH_CLK $FLASH_OPTIONS
+
+$CHIPNAME.cpu configure -event reset-end {
+    # Set the PC to the load address where the interrupt vector is stored
+    reg pc Reset_Handler
+}


### PR DESCRIPTION
This PR adds the latest target config files for ADI MAX32xxx and MAX78xxx MCUs pulled over from our [previous fork of openocd](https://github.com/Analog-Devices-MSDK/openocd)

This is also a transfer over of https://github.com/Analog-Devices-MSDK/openocd/pull/19 to enable thread-aware debugging via rtos auto-detection for all MCUs.