### PR TITLE
.github: fix Cloudsmith package publish paths

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -246,5 +246,5 @@ jobs:
 
       - name: Publish to Cloudsmith
         run: |
-          cloudsmith push deb adi/external/any-distro/any-version *.deb
-          cloudsmith push rpm adi/external/any-distro/any-version *.rpm
+          cloudsmith push deb adi/external/any-distro/any-version ./pkgs/*.deb
+          cloudsmith push rpm adi/external/any-distro/any-version ./pkgs/*.rpm


### PR DESCRIPTION
Publish step downloaded release artifacts into `./pkgs` but attempted to push `*.deb` and `*.rpm` from the repository root.

Update the Cloudsmith publish commands to use the downloaded package paths so release uploads can find the generated DEB and RPM files.

Fixes: 9e0f8ac (".github: add release workflow and packaging support")